### PR TITLE
Corregir la vista index de grupos

### DIFF
--- a/app/views/grupos/index.html.haml
+++ b/app/views/grupos/index.html.haml
@@ -17,6 +17,6 @@
         %td= grupo.descripcion
         %td
           = link_to t('.edit', default: t("helpers.links.edit")), edit_grupo_path(grupo), class: 'btn btn-mini'
-          = link_to t('.destroy', default: t("helpers.links.destroy")), grupo_path(grupo), method: :delete, data: { confirm: t('.confirm', :default: t("helpers.links.confirm", default: 'Are you sure?')) }, class: 'btn btn-mini btn-danger'
+          = link_to t('.destroy', default: t("helpers.links.destroy")), grupo_path(grupo), method: :delete, data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) }, class: 'btn btn-mini btn-danger'
 
 = link_to t('.new', default: t("helpers.links.new")), new_grupo_path, class: 'btn btn-primary'


### PR DESCRIPTION
Corregir la vista index del grupo:
/home/action/workspace/calific.app_reloaded/app/views/grupos/index.html.haml:20: syntax error, unexpected ':', expecting ')'
...onfirm: t('.confirm', :default: t("helpers.links.confirm", d...
                                ^
